### PR TITLE
chore: migrate renovate preset to tasshi-me/configs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>tasshi-me/renovate-config"
+    "local>tasshi-me/configs"
   ]
 }


### PR DESCRIPTION
The shareable Renovate preset moved from `tasshi-me/renovate-config` to [`tasshi-me/configs`](https://github.com/tasshi-me/configs). This updates the `extends` reference accordingly. `renovate-config` will be archived afterwards.